### PR TITLE
fix(AHWR-797): When response results in failures ensure relevant logg…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-payment",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-payment",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/data-tables": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-payment",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "FFC Vet Visits Payment Service",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-payment",
   "main": "app/index.js",


### PR DESCRIPTION
…ing and exception tracking

Ensure we log out the response properly (without dropping the extra info).

in the event the response indicates that the request failed, track appropriate exception so that it actually invokes alerts, and let's us see the reason for the failure.