### PR TITLE
feat(AHWR-1160): Allow on demand retry check of PAID status

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -10,9 +10,9 @@ const schema = joi.object({
   isDev: joi.boolean(),
   sendPaymentRequestOutbound: joi.boolean().required(),
   requestPaymentStatusScheduler: {
-    enabled: joi.bool(),
-    schedule: joi.string(),
-    initialAttempts: joi.number()
+    enabled: joi.bool().required(),
+    schedule: joi.string().required(),
+    initialAttempts: joi.number().required()
   },
   checkStatusRequestType: joi.string().required()
 })

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -11,8 +11,10 @@ const schema = joi.object({
   sendPaymentRequestOutbound: joi.boolean().required(),
   requestPaymentStatusScheduler: {
     enabled: joi.bool(),
-    schedule: joi.string()
-  }
+    schedule: joi.string(),
+    initialAttempts: joi.number()
+  },
+  checkStatusRequestType: joi.string().required()
 })
 
 const baseConfig = {
@@ -22,8 +24,10 @@ const baseConfig = {
   sendPaymentRequestOutbound: process.env.SEND_PAYMENT_REQUEST === 'true',
   requestPaymentStatusScheduler: {
     enabled: process.env.REQUEST_PAYMENT_STATUS_ENABLED === 'true',
-    schedule: process.env.REQUEST_PAYMENT_STATUS_SCHEDULE ?? '0 11 * * 1-5'
-  }
+    schedule: process.env.REQUEST_PAYMENT_STATUS_SCHEDULE ?? '0 11 * * 1-5',
+    initialAttempts: Number.parseInt(process.env.REQUEST_PAYMENT_INITIAL_ATTEMPTS ?? '3', 10)
+  },
+  checkStatusRequestType: 'uk.gov.ffc.ahwr.check.status.request'
 }
 
 const { error } = schema.validate(baseConfig, { abortEarly: false })

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -50,7 +50,6 @@ export const PaymentHubStatus = {
   SETTLED: 'Settled'
 }
 
-export const DAILY_RETRY_LIMIT = 3
 export const DAILY_RETRY_FROM_DAYS = 1
 
 export const FINAL_RETRY_DAYS = 10

--- a/app/jobs/request-payment-status.js
+++ b/app/jobs/request-payment-status.js
@@ -9,7 +9,7 @@ import {
 } from '../repositories/payment-repository.js'
 import { createBlobClient } from '../storage.js'
 import { v4 as uuid } from 'uuid'
-import { DAILY_RETRY_LIMIT, PaymentHubStatus, Status } from '../constants/constants.js'
+import { PaymentHubStatus, Status } from '../constants/constants.js'
 import appInsights from 'applicationinsights'
 
 const {
@@ -17,6 +17,9 @@ const {
     moveClaimToPaidMsgType,
     applicationRequestQueue,
     paymentDataRequestResponseQueue
+  },
+  requestPaymentStatusScheduler: {
+    initialAttempts: DAILY_RETRY_LIMIT
   }
 } = config
 
@@ -83,7 +86,7 @@ const processPaymentDataEntry = async (paymentDataEntry, logger) => {
     trackPaymentStatusError({ claimReference, statuses, sbi, type: 'INITIAL', logger, paymentCheckCount })
   }
 
-  if (paymentCheckCount > DAILY_RETRY_LIMIT) {
+  if (paymentCheckCount === DAILY_RETRY_LIMIT + 1) {
     trackPaymentStatusError({ claimReference, statuses, sbi, type: 'FINAL', logger, paymentCheckCount })
   }
 }
@@ -107,7 +110,7 @@ const createReceiver = async (messageId) => {
   return receiver
 }
 
-const processFrnRequest = async (frn, logger, claimReferences) => {
+export const processFrnRequest = async (frn, logger, claimReferences) => {
   const requestMessageId = uuid()
   const sessionId = uuid()
   const requestMessage = createPaymentDataRequest(frn)

--- a/app/messaging/index.js
+++ b/app/messaging/index.js
@@ -1,25 +1,32 @@
 import { MessageReceiver } from 'ffc-messaging'
 import { processApplicationPaymentRequest } from './process-application-payment-request.js'
 import { processPaymentResponse } from './process-payment-response.js'
-import { config } from '../config/message-queue.js'
+import { config } from '../config/index.js'
+import { processCheckStatusRequest } from './process-check-status-request.js'
 
 let applicationClaimReceiver
 let paymentActionReceiver
 
 export const start = async (logger) => {
-  const { applicationPaymentRequestQueue, paymentResponseSubscription } = config
+  const { messageQueueConfig: { applicationPaymentRequestQueue, paymentResponseSubscription }, checkStatusRequestType } = config
+
   const applicationClaimAction = message => {
     const childLogger = logger.child({})
-    processApplicationPaymentRequest(childLogger, message, applicationClaimReceiver)
+    const { applicationProperties } = message
+    if (applicationProperties.type === checkStatusRequestType) {
+      processCheckStatusRequest(childLogger, message, applicationClaimReceiver)
+    } else {
+      processApplicationPaymentRequest(childLogger, message, applicationClaimReceiver)
+    }
   }
   applicationClaimReceiver = new MessageReceiver(applicationPaymentRequestQueue, applicationClaimAction)
   await applicationClaimReceiver.subscribe()
 
-  const paymentRequestAction = message => {
+  const paymentResponseAction = message => {
     const childLogger = logger.child({})
     processPaymentResponse(childLogger, message, paymentActionReceiver)
   }
-  paymentActionReceiver = new MessageReceiver(paymentResponseSubscription, paymentRequestAction)
+  paymentActionReceiver = new MessageReceiver(paymentResponseSubscription, paymentResponseAction)
   await paymentActionReceiver.subscribe()
 
   logger.info('Ready to receive messages')

--- a/app/messaging/index.js
+++ b/app/messaging/index.js
@@ -7,17 +7,13 @@ import { processCheckStatusRequest } from './process-check-status-request.js'
 let applicationClaimReceiver
 let paymentActionReceiver
 
+const { checkStatusRequestType } = config
+
 export const start = async (logger) => {
-  const { messageQueueConfig: { applicationPaymentRequestQueue, paymentResponseSubscription }, checkStatusRequestType } = config
+  const { messageQueueConfig: { applicationPaymentRequestQueue, paymentResponseSubscription } } = config
 
   const applicationClaimAction = message => {
-    const childLogger = logger.child({})
-    const { applicationProperties } = message
-    if (applicationProperties.type === checkStatusRequestType) {
-      processCheckStatusRequest(childLogger, message, applicationClaimReceiver)
-    } else {
-      processApplicationPaymentRequest(childLogger, message, applicationClaimReceiver)
-    }
+    routeMessage(message, logger)
   }
   applicationClaimReceiver = new MessageReceiver(applicationPaymentRequestQueue, applicationClaimAction)
   await applicationClaimReceiver.subscribe()
@@ -35,4 +31,14 @@ export const start = async (logger) => {
 export const stop = async () => {
   await applicationClaimReceiver.closeConnection()
   await paymentActionReceiver.closeConnection()
+}
+
+export const routeMessage = async (message, logger) => {
+  const childLogger = logger.child({})
+  const { applicationProperties } = message
+  if (applicationProperties.type === checkStatusRequestType) {
+    processCheckStatusRequest(childLogger, message, applicationClaimReceiver)
+  } else {
+    processApplicationPaymentRequest(childLogger, message, applicationClaimReceiver)
+  }
 }

--- a/app/messaging/process-check-status-request.js
+++ b/app/messaging/process-check-status-request.js
@@ -1,0 +1,35 @@
+import { get } from '../repositories/payment-repository.js'
+import { processFrnRequest } from '../jobs/request-payment-status.js'
+import joi from 'joi'
+
+const checkStatusRequestSchema = joi.object({
+  reference: joi.string().required()
+})
+
+export const processCheckStatusRequest = async (logger, message, receiver) => {
+  try {
+    const { reference } = message.body
+    logger.setBindings({ reference })
+    logger.info('Received check status request')
+    const { error } = checkStatusRequestSchema.validate(message.body)
+    if (error) {
+      logger.error(error, 'Check status request validation error')
+      throw new Error('Invalid message')
+    }
+    // get the record from DB
+    const existingRecord = await get(reference)
+
+    if (!existingRecord) {
+      logger.info(`No payment request found for reference ${reference}`)
+      throw new Error(`No payment request found for reference ${reference}`)
+    }
+    const { dataValues: { frn } } = existingRecord
+
+    await processFrnRequest(frn, logger, new Set([reference]))
+    await receiver.completeMessage(message)
+  } catch (err) {
+    await receiver.deadLetterMessage(message)
+
+    logger.error(`Unable to process check status request: ${err}`)
+  }
+}

--- a/app/repositories/payment-repository.js
+++ b/app/repositories/payment-repository.js
@@ -1,8 +1,14 @@
-import { DAILY_RETRY_FROM_DAYS, DAILY_RETRY_LIMIT, FINAL_RETRY_DAYS, Status } from '../constants/constants.js'
+import { DAILY_RETRY_FROM_DAYS, FINAL_RETRY_DAYS, Status } from '../constants/constants.js'
+import { config } from '../config/index.js'
 import dataModels from '../data/index.js'
 import { Op } from 'sequelize'
 import { subDays } from 'date-fns'
 
+const {
+  requestPaymentStatusScheduler: {
+    initialAttempts: DAILY_RETRY_LIMIT
+  }
+} = config
 const { models } = dataModels
 
 export async function get (reference) {

--- a/helm/ffc-ahwr-payment/templates/config-map.yaml
+++ b/helm/ffc-ahwr-payment/templates/config-map.yaml
@@ -21,4 +21,5 @@ data:
   PAYMENT_DATA_REQUEST_RESPONSE_QUEUE_ADDRESS: {{ quote .Values.container.paymentDataRequestResponseQueueAddress }}
   REQUEST_PAYMENT_STATUS_ENABLED: {{ quote .Values.container.requestPaymentStatusEnabled }}
   REQUEST_PAYMENT_STATUS_SCHEDULE: {{ quote .Values.container.requestPaymentStatusSchedule }}
+  REQUEST_PAYMENT_INITIAL_ATTEMPTS: {{ quote .Values.container.requestPaymentInitialAttempts }}
 {{- end -}}

--- a/helm/ffc-ahwr-payment/values.yaml
+++ b/helm/ffc-ahwr-payment/values.yaml
@@ -48,6 +48,7 @@ container:
   paymentDataRequestResponseQueueAddress: ffc-pay-data-request-response
   requestPaymentStatusEnabled: "false"
   requestPaymentStatusSchedule: 0 20 * * 1-5
+  requestPaymentInitialAttempts: 3
   imagePullPolicy: IfNotPresent
   requestMemory: 10Mi
   requestCpu: 10m

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-payment",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-payment",
-      "version": "2.4.2",
+      "version": "2.5.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/data-tables": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-payment",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "FFC Vet Visits Payment Service",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-payment",
   "main": "app/index.js",

--- a/test/unit/app/config/index.test.js
+++ b/test/unit/app/config/index.test.js
@@ -1,0 +1,48 @@
+describe('Main Config Test', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...OLD_ENV }
+
+    // set the required messaging env vars as that file will also be loaded during this test
+    process.env.PAYMENTREQUEST_TOPIC_ADDRESS = 'topic-address'
+    process.env.PAYMENTRESPONSE_TOPIC_ADDRESS = 'topic-address'
+    process.env.PAYMENTRESPONSE_SUBSCRIPTION_ADDRESS = 'subscription-address'
+    process.env.PAYMENT_DATA_REQUEST_RESPONSE_QUEUE_ADDRESS = 'payment-data-request-response-queue-address'
+    process.env.APPLICATION_REQUEST_QUEUE_ADDRESS = 'application-request-queue-address'
+    process.env.PAYMENTREQUEST_TOPIC_ADDRESS = 'payment-request-topic-address'
+  })
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+  test('Should pass validation for all fields populated using supplied values', async () => {
+    process.env.SEND_PAYMENT_REQUEST = 'false'
+    process.env.REQUEST_PAYMENT_STATUS_ENABLED = 'false'
+    process.env.REQUEST_PAYMENT_STATUS_SCHEDULE = '0 0 0 0 0'
+    process.env.REQUEST_PAYMENT_INITIAL_ATTEMPTS = '4'
+
+    const { config } = jest.requireActual('../../../../app/config/index.js')
+    expect(config).toBeDefined()
+    expect(config.requestPaymentStatusScheduler.enabled).toBeFalsy()
+    expect(config.requestPaymentStatusScheduler.schedule).toEqual('0 0 0 0 0')
+    expect(config.requestPaymentStatusScheduler.initialAttempts).toEqual(4)
+    expect(config.sendPaymentRequestOutbound).toBeFalsy()
+  })
+
+  test('Should pass validation for all fields populated using default values', async () => {
+    process.env.SEND_PAYMENT_REQUEST = 'true'
+    process.env.REQUEST_PAYMENT_STATUS_ENABLED = 'true'
+    delete process.env.REQUEST_PAYMENT_STATUS_SCHEDULE
+    delete process.env.REQUEST_PAYMENT_INITIAL_ATTEMPTS
+
+    const { config } = jest.requireActual('../../../../app/config/index.js')
+    expect(config).toBeDefined()
+    expect(config.requestPaymentStatusScheduler.enabled).toBeTruthy()
+    expect(config.requestPaymentStatusScheduler.schedule).toEqual('0 11 * * 1-5')
+    expect(config.requestPaymentStatusScheduler.initialAttempts).toEqual(3)
+    expect(config.sendPaymentRequestOutbound).toBeTruthy()
+  })
+})

--- a/test/unit/app/jobs/request-payment-status.test.js
+++ b/test/unit/app/jobs/request-payment-status.test.js
@@ -2,7 +2,7 @@ import { incrementPaymentCheckCount, updatePaymentStatusByClaimRef, getPendingPa
 import { sendPaymentDataRequest } from '../../../../app/messaging/send-payment-data-request'
 import { sendMessage } from '../../../../app/messaging/send-message'
 import { createBlobClient } from '../../../../app/storage.js'
-import { requestPaymentStatus } from '../../../../app/jobs/request-payment-status'
+import { processFrnRequest, requestPaymentStatus } from '../../../../app/jobs/request-payment-status'
 import { MessageReceiver } from 'ffc-messaging'
 import { defaultClient } from 'applicationinsights'
 import waitingForLedgerResponse from '../../../data/data-requests/0c8f8076-ff05-43cb-91f2-13d7abec9f6b.json'
@@ -18,6 +18,9 @@ jest.mock('../../../../app/config', () => ({
       moveClaimToPaidMsgType: 'move-claim-to-paid-msg-type',
       applicationRequestQueue: 'application-request-queue',
       paymentDataRequestResponseQueue: 'payment-data-request-response-queue'
+    },
+    requestPaymentStatusScheduler: {
+      initialAttempts: 3
     }
   }
 }))
@@ -266,6 +269,30 @@ describe('requestPaymentStatus', () => {
         type: 'FINAL'
       }
     })
+  })
+
+  test('does not raise appInsights exception when the delayed retry limit has been exceeded', async () => {
+    getBlobMock.mockResolvedValue(waitingForLedgerResponse)
+
+    incrementPaymentCheckCount.mockResolvedValue({
+      id: '32742adb-f37d-4bc8-8927-7f7d7cfc685e',
+      applicationReference: 'RESH-F99F-E09F',
+      data: { sbi: '234234', value: 436, invoiceLines: [{ value: 436, description: 'G00 - Gross value of claim', standardCode: 'AHWR-Sheep' }], sourceSystem: 'AHWR', marketingYear: 2025, agreementNumber: 'ABC-1234', paymentRequestNumber: 1 },
+      createdAt: '2025-06-25T08:24:56.309Z',
+      updatedAt: '2025-07-11T15:49:20.297Z',
+      status: 'ack',
+      paymentResponse: [{}],
+      paymentCheckCount: '5',
+      frn: '1100306986'
+    })
+
+    await processFrnRequest('1100306986', loggerMock, new Set(['RESH-F99F-E09F']))
+
+    expect(incrementPaymentCheckCount).toHaveBeenCalledWith('RESH-F99F-E09F')
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(deleteBlobMock).toHaveBeenCalled()
+    expect(completeMessageMock).toHaveBeenCalled()
+    expect(defaultClient.trackException).not.toHaveBeenCalled()
   })
 
   test('does not raise appInsights exception when no payments were found to increment paymentCheckCount', async () => {

--- a/test/unit/app/messaging/index.test.js
+++ b/test/unit/app/messaging/index.test.js
@@ -1,5 +1,7 @@
 import { MessageReceiver } from 'ffc-messaging'
-import { start, stop } from '../../../../app/messaging'
+import { routeMessage, start, stop } from '../../../../app/messaging'
+import { processCheckStatusRequest } from '../../../../app/messaging/process-check-status-request.js'
+import { processApplicationPaymentRequest } from '../../../../app/messaging/process-application-payment-request.js'
 
 jest.mock('ffc-messaging')
 jest.mock('../../../../app/config/message-queue', () => ({
@@ -8,8 +10,8 @@ jest.mock('../../../../app/config/message-queue', () => ({
     paymentResponseSubscription: 'payment-response-subscription'
   }
 }))
-jest.mock('../../../../app/messaging/process-check-status-request.js', () => ({}))
-jest.mock('../../../../app/messaging/process-application-payment-request.js', () => ({}))
+jest.mock('../../../../app/messaging/process-check-status-request.js')
+jest.mock('../../../../app/messaging/process-application-payment-request.js')
 
 const mocksubscribe = jest.fn()
 const mockClose = jest.fn()
@@ -25,5 +27,33 @@ describe(('Message receivers'), () => {
   test('successfully stopped receivers', async () => {
     await stop()
     expect(mockClose).toHaveBeenCalledTimes(2)
+  })
+
+  test('route inbound message to processApplicationPaymentRequest', async () => {
+    const mockMessage = {
+      applicationProperties: {
+        type: 'uk.gov.ffc.ahwr.application.payment.request'
+      },
+      body: { reference: 'ABCD-1234-5678', amount: 555 }
+    }
+    const mockChild = jest.fn()
+    const mockLogger = { child: jest.fn(() => mockChild) }
+    await routeMessage(mockMessage, mockLogger)
+    expect(mockLogger.child).toHaveBeenCalledTimes(1)
+    expect(processApplicationPaymentRequest).toHaveBeenCalledWith(mockChild, mockMessage, expect.anything())
+  })
+
+  test('route inbound message to processCheckStatusRequest', async () => {
+    const mockMessage = {
+      applicationProperties: {
+        type: 'uk.gov.ffc.ahwr.check.status.request'
+      },
+      body: { reference: 'ABCD-1234-5678' }
+    }
+    const mockChild = jest.fn()
+    const mockLogger = { child: jest.fn(() => mockChild) }
+    await routeMessage(mockMessage, mockLogger)
+    expect(mockLogger.child).toHaveBeenCalledTimes(1)
+    expect(processCheckStatusRequest).toHaveBeenCalledWith(mockChild, mockMessage, expect.anything())
   })
 })

--- a/test/unit/app/messaging/index.test.js
+++ b/test/unit/app/messaging/index.test.js
@@ -8,6 +8,8 @@ jest.mock('../../../../app/config/message-queue', () => ({
     paymentResponseSubscription: 'payment-response-subscription'
   }
 }))
+jest.mock('../../../../app/messaging/process-check-status-request.js', () => ({}))
+jest.mock('../../../../app/messaging/process-application-payment-request.js', () => ({}))
 
 const mocksubscribe = jest.fn()
 const mockClose = jest.fn()

--- a/test/unit/app/messaging/process-check-status-request.test.js
+++ b/test/unit/app/messaging/process-check-status-request.test.js
@@ -47,8 +47,8 @@ describe(('Process check status request'), () => {
   })
 
   test('when validation fails message is dead-lettered', async () => {
-    await processCheckStatusRequest(mockedLogger, {}, receiver)
-    expect(mockErrorLogger).toHaveBeenCalledTimes(1)
+    await processCheckStatusRequest(mockedLogger, { body: {} }, receiver)
+    expect(mockErrorLogger).toHaveBeenCalledTimes(2)
     expect(receiver.deadLetterMessage).toHaveBeenCalledTimes(1)
   })
 

--- a/test/unit/app/messaging/process-check-status-request.test.js
+++ b/test/unit/app/messaging/process-check-status-request.test.js
@@ -1,0 +1,63 @@
+import { processCheckStatusRequest } from '../../../../app/messaging/process-check-status-request.js'
+import { get } from '../../../../app/repositories/payment-repository.js'
+import { processFrnRequest } from '../../../../app/jobs/request-payment-status.js'
+jest.mock('applicationinsights', () => ({ defaultClient: { trackException: jest.fn(), trackEvent: jest.fn() }, dispose: jest.fn() }))
+jest.mock('../../../../app/config', () => ({
+  config: {
+    messageQueueConfig: {
+      submitPaymentRequestMsgType: 'submit.payment.request'
+    },
+    requestPaymentStatusScheduler: {
+      initialAttempts: 3
+    }
+  }
+}))
+jest.mock('../../../../app/repositories/payment-repository.js')
+jest.mock('../../../../app/jobs/request-payment-status.js')
+
+const mockInfoLogger = jest.fn()
+const mockErrorLogger = jest.fn()
+const mockSetBindings = jest.fn()
+
+const mockedLogger = {
+  info: mockInfoLogger,
+  error: mockErrorLogger,
+  setBindings: mockSetBindings
+}
+
+describe(('Process check status request'), () => {
+  const receiver = {
+    completeMessage: jest.fn(),
+    abandonMessage: jest.fn(),
+    deadLetterMessage: jest.fn()
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  test('Successfully call processFrnRequest and complete message', async () => {
+    get.mockResolvedValueOnce({ dataValues: { frn: 'frn12345' } })
+    await processCheckStatusRequest(mockedLogger, { body: { reference: 'ABCD-1234-5678' } }, receiver)
+
+    expect(get).toHaveBeenCalledWith('ABCD-1234-5678')
+    expect(processFrnRequest).toHaveBeenCalledWith('frn12345', mockedLogger, new Set(['ABCD-1234-5678']))
+    expect(mockInfoLogger).toHaveBeenCalledTimes(1)
+    expect(receiver.completeMessage).toHaveBeenCalledTimes(1)
+  })
+
+  test('when validation fails message is dead-lettered', async () => {
+    await processCheckStatusRequest(mockedLogger, {}, receiver)
+    expect(mockErrorLogger).toHaveBeenCalledTimes(1)
+    expect(receiver.deadLetterMessage).toHaveBeenCalledTimes(1)
+  })
+
+  test('when no existing record found message is dead-lettered', async () => {
+    get.mockResolvedValueOnce(null)
+    await processCheckStatusRequest(mockedLogger, { body: { reference: 'ABCD-1234-5678' } }, receiver)
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledWith('ABCD-1234-5678')
+    expect(mockErrorLogger).toHaveBeenCalledTimes(1)
+    expect(receiver.deadLetterMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/unit/app/messaging/save-payment-request.test.js
+++ b/test/unit/app/messaging/save-payment-request.test.js
@@ -12,14 +12,6 @@ jest.mock('../../../../app/storage', () => ({
 }))
 jest.mock('../../../../app/messaging/send-message')
 jest.mock('../../../../app/messaging/payment-request-schema')
-jest.mock('../../../../app/config', () => ({
-  storage: {
-    storageAccount: 'mockStorageAccount',
-    useConnectionString: false,
-    endemicsSettingsContainer: 'endemics-settings',
-    connectionString: 'connectionString'
-  }
-}))
 jest.mock('applicationinsights', () => ({ defaultClient: { trackException: jest.fn(), trackEvent: jest.fn() }, dispose: jest.fn() }))
 
 const paymentRepoGetSpy = jest.spyOn(paymentRepo, 'get')


### PR DESCRIPTION
Poke in a message with specific type, including the reference in body, to do an on demand check for if it has been paid. We can retry beyond the usual max, but we'll still increment the DB counter. We won't keep raising alerts beyond the initial checks + 1 range, as I don't see any benefit to that.
This is compatible with the scheduled checks, so it also lets us for instance bring forward the 'final' check if we don't want to wait the full 10 days, as well as letting us try a 5th, 6th, 7th etc time.

I have also made the initial attempts count configurable as we might want to tweak beyond the 3 we went with originally. I don;t yet see evidence to actually change this, but added option to allow it if we wanted the opportunity to.

The input message shape to do a check is very simple:
<img width="676" height="665" alt="Screenshot 2025-08-06 at 16 17 19" src="https://github.com/user-attachments/assets/7a0bf444-8f42-4ff0-8a7e-752e78885d93" />
